### PR TITLE
fix(github-repo-stats): oversized github logo icon for safari browsers

### DIFF
--- a/dashboard/src/features/github-repo/github-repo.tsx
+++ b/dashboard/src/features/github-repo/github-repo.tsx
@@ -25,7 +25,7 @@ export const GithubRepo: FC<GithubRepoProps> = ({ variant = "full", stargazers_c
             <Card>
                 <a href={projectInfo.github} target="_blank">
                     <CardContent className="hstack size-fit p-0 gap-2 items-center">
-                        <GithubIcon className="size-fit" />
+                        <GithubIcon className="size-6" />
                         {variant === "full" ? (
                             <div className="vstack items-start">
                                 <CardTitle className="font-mono text-xs hstack justify-between w-full">


### PR DESCRIPTION
## Description

Github icon of repo statistics gets oversized for safari browsers both in mobile and desktop versions.

### Screenshots

![image](https://github.com/user-attachments/assets/f4e6a95a-72fc-4024-bb15-e67ff860a705)
![image](https://github.com/user-attachments/assets/17d39275-367e-4acb-91f6-7f1f750b90a4)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests (stories, interaction tests, unit tests, e2e tests) to cover my changes.
