### PR TITLE
improve(entity-table): resetting back to page 1 when filters changes

### DIFF
--- a/dashboard/src/features/entity-table/components/column-header-combo-filter.tsx
+++ b/dashboard/src/features/entity-table/components/column-header-combo-filter.tsx
@@ -44,9 +44,8 @@ export function DataTableColumnHeaderFilterOption<TData, TValue>(
     }
 
     React.useEffect(() => {
-        if (table.getState().pagination.pageIndex === 1) table.setPageIndex(2);
-        else table.setPageIndex(1);
-    }, [table, selectedOption])
+        table.setPageIndex(1);
+    }, [filters, selectedOption])
 
     if (isDesktop) {
         return (

--- a/dashboard/src/features/entity-table/components/column-header-combo-filter.tsx
+++ b/dashboard/src/features/entity-table/components/column-header-combo-filter.tsx
@@ -44,7 +44,8 @@ export function DataTableColumnHeaderFilterOption<TData, TValue>(
     }
 
     React.useEffect(() => {
-        table.setPageIndex(1);
+        if (table.getState().pagination.pageIndex === 1) table.setPageIndex(2);
+        else table.setPageIndex(1);
     }, [table, selectedOption])
 
     if (isDesktop) {

--- a/dashboard/src/features/entity-table/components/column-header-combo-filter.tsx
+++ b/dashboard/src/features/entity-table/components/column-header-combo-filter.tsx
@@ -36,12 +36,16 @@ export function DataTableColumnHeaderFilterOption<TData, TValue>(
     const [selectedOption, setSelectedOption] = React.useState<string | null>(
         null
     )
-    const { filters } = useEntityTableContext();
+    const { filters, table } = useEntityTableContext();
 
     function handleClearingFilter() {
         filters.setColumnsFilter({ ...filters.columnsFilter, [column.id]: undefined });
         setSelectedOption(null);
     }
+
+    React.useEffect(() => {
+        table.setPageIndex(1);
+    }, [table, selectedOption])
 
     if (isDesktop) {
         return (

--- a/dashboard/src/features/entity-table/components/column-header-combo-filter.tsx
+++ b/dashboard/src/features/entity-table/components/column-header-combo-filter.tsx
@@ -44,8 +44,9 @@ export function DataTableColumnHeaderFilterOption<TData, TValue>(
     }
 
     React.useEffect(() => {
+        // if (table.getState().pagination.pageIndex !== 1)
         table.setPageIndex(1);
-    }, [filters, selectedOption])
+    }, [table, selectedOption])
 
     if (isDesktop) {
         return (

--- a/dashboard/src/features/entity-table/components/table-pagination.tsx
+++ b/dashboard/src/features/entity-table/components/table-pagination.tsx
@@ -63,10 +63,12 @@ export function DataTablePagination<TData>({ table }: { table: Table<TData> }) {
                         </SelectContent>
                     </Select>
                 </div>
-                <div className="flex justify-center items-center text-sm font-medium w-[100px]">
-                    Page {table.getState().pagination.pageIndex + 1} of{" "}
-                    {table.getPageCount() - 1}
-                </div>
+                {(table.getPageCount() - 1) !== 0 &&
+                    <div className="flex justify-center items-center text-sm font-medium w-[100px]">
+                        Page {table.getState().pagination.pageIndex + 1} of{" "}
+                        {table.getPageCount() - 1}
+                    </div>
+                }
                 <div className="flex items-center space-x-2">
                     <Button
                         variant="outline"

--- a/dashboard/src/features/entity-table/components/table-pagination.tsx
+++ b/dashboard/src/features/entity-table/components/table-pagination.tsx
@@ -21,7 +21,6 @@ export function DataTablePagination<TData>({ table }: { table: Table<TData> }) {
 
     useEffect(() => {
         if (table.getState().pagination.pageIndex === 1) table.setPageIndex(2);
-        if (table.getState().pagination.pageIndex === 0) table.setPageIndex(1);
     }, [table]);
 
     return (

--- a/dashboard/src/features/entity-table/components/table-pagination.tsx
+++ b/dashboard/src/features/entity-table/components/table-pagination.tsx
@@ -21,6 +21,7 @@ export function DataTablePagination<TData>({ table }: { table: Table<TData> }) {
 
     useEffect(() => {
         if (table.getState().pagination.pageIndex === 1) table.setPageIndex(2);
+        if (table.getState().pagination.pageIndex === 0) table.setPageIndex(1);
     }, [table]);
 
     return (

--- a/dashboard/src/features/entity-table/components/table-pagination.tsx
+++ b/dashboard/src/features/entity-table/components/table-pagination.tsx
@@ -13,15 +13,10 @@ import {
     SelectValue,
 } from "@marzneshin/components";
 import { useTranslation } from "react-i18next";
-import { useEffect } from "react";
 import { Table } from "@tanstack/react-table"
 
 export function DataTablePagination<TData>({ table }: { table: Table<TData> }) {
     const { t } = useTranslation();
-
-    useEffect(() => {
-        if (table.getState().pagination.pageIndex === 1) table.setPageIndex(2);
-    }, [table]);
 
     return (
         <div className="flex justify-between items-center p-2 w-full">

--- a/dashboard/src/features/users/services/users.query.ts
+++ b/dashboard/src/features/users/services/users.query.ts
@@ -15,7 +15,8 @@ export async function fetchUsers({ queryKey }: EntityQueryKeyType): FetchEntityR
     const filters = queryKey[4].filters;
     return fetch(`/users`, {
         query: {
-            ...pagination,
+            page: pagination.page === 0 ? 1 : pagination.page,
+            size: pagination.size,
             ...filters,
             username: primaryFilter,
             descending: queryKey[3].desc,


### PR DESCRIPTION
## Description

Resetting back to page 1 when filters changes

## Checklist
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests (stories, interaction tests, unit tests, e2e tests) to cover my changes.
