### PR TITLE
fix: Correct JSON schema example to use 'service_ids' instead of 'services'

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -68,7 +68,7 @@ class UserCreate(User):
         json_schema_extra={
             "example": {
                 "username": "user1234",
-                "services": [1, 2, 3],
+                "service_ids": [1, 2, 3],
                 "expire_strategy": "start_on_first_use",
                 "usage_duration": 86400 * 14,
                 "activation_deadline": "2024-11-03T20:30:00",


### PR DESCRIPTION
## Description


## UI Changes

-
-

### Screenshots

## API Changes

## Checklist
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests (stories, interaction tests, unit tests, e2e tests) to cover my changes.
- [ ] I have added tests to cover my changes.

## Related Issues

Closes

- #
- #

