### PR TITLE
fix: Update validation for user expiry strategies

### DIFF
--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -423,6 +423,16 @@ def update_user(
     if modify.expire_strategy is not None:
         dbuser.expire_strategy = modify.expire_strategy or None
 
+        if modify.expire_strategy == UserExpireStrategy.FIXED_DATE:
+            dbuser.usage_duration = None
+            dbuser.activation_deadline = None
+        elif modify.expire_strategy == UserExpireStrategy.START_ON_FIRST_USE:
+            dbuser.expire_date = None
+        elif modify.expire_strategy == UserExpireStrategy.NEVER:
+            dbuser.expire_date = None
+            dbuser.usage_duration = None
+            dbuser.activation_deadline = None
+
     if modify.expire_date is not None:
         dbuser.expire_date = modify.expire_date or None
 


### PR DESCRIPTION
- Set expire_date, usage_duration, and activation_deadline to None when using NEVER expiration strategy.
- Set expire_date to None when using START_ON_FIRST_USE expiration strategy.
- Set usage_duration and activation_deadline are set to None when using FIXED_DATE expiration strategy.
- Ensure that these changes are correctly reflected in the database.

## Description

Provide a small description of Pull Request.

## UI Changes

-
-

### Screenshots

## API Changes

## Checklist
- 

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests (stories, interaction tests, unit tests, e2e tests) to cover my changes.
- [ ] I have added tests to cover my changes.

## Related Issues

Closes

- #
- #

