### PR TITLE
fix(users): consider not having an owner

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -264,7 +264,9 @@ class User(Base):
 
     @property
     def subscription_url(self):
-        prefix = self.admin.subscription_url_prefix or SUBSCRIPTION_URL_PREFIX
+        prefix = (
+            self.admin.subscription_url_prefix if self.admin else None
+        ) or SUBSCRIPTION_URL_PREFIX
         return (
             prefix.replace("*", secrets.token_hex(8))
             + f"/sub/{self.username}/{self.key}"
@@ -272,7 +274,7 @@ class User(Base):
 
     @hybrid_property
     def owner_username(self):
-        return self.admin.username
+        return self.admin.username if self.admin else None
 
 
 class Backend(Base):

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -140,7 +140,7 @@ class UserResponse(User):
     created_at: datetime
     service_ids: list[int]
     subscription_url: str
-    owner_username: str
+    owner_username: str | None
     traffic_reset_at: datetime | None
 
     model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Description

In case an admin gets removed, its users would not have an owner. and owner_username would be set to null. The fix considers and adapts this scenario. 