### PR TITLE
Fix expire color for fixed_date

### DIFF
--- a/dashboard/src/modules/users/components/pills/user-expire-strategy-pill.tsx
+++ b/dashboard/src/modules/users/components/pills/user-expire-strategy-pill.tsx
@@ -1,4 +1,3 @@
-
 import { type FC } from "react";
 import { Badge } from "@marzneshin/common/components";
 import { useTranslation } from "react-i18next";
@@ -13,7 +12,7 @@ export const UserExpireStrategyPill: FC<UserProp> = ({ user }) => {
     }[user.expire_strategy]
     const variant = {
         start_on_first_use: "royal",
-        fixed_date: "warning",
+        fixed_date: "royal",
         never: "disabled",
     }[user.expire_strategy]
     return (
@@ -22,4 +21,3 @@ export const UserExpireStrategyPill: FC<UserProp> = ({ user }) => {
         </Badge>
     )
 }
-


### PR DESCRIPTION
Fixes #668

Change the expire color for "fixed_date" to a less alarming color.

* Update the `variant` object in `dashboard/src/modules/users/components/pills/user-expire-strategy-pill.tsx` to map "fixed_date" to "royal" instead of "warning".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/marzneshin/marzneshin/pull/673?shareId=a1b03e91-b5dd-48be-8d5b-c217bc5049ed).