### PR TITLE
fix(usage-duration-field):  

### DIFF
--- a/dashboard/src/modules/users/components/dialogs/mutation/fields/usage-duration.tsx
+++ b/dashboard/src/modules/users/components/dialogs/mutation/fields/usage-duration.tsx
@@ -14,11 +14,11 @@ export const UsageDurationField: FC = () => {
     const form = useFormContext();
     const { t } = useTranslation();
 
-    const defaultDuration = (form.getValues('usage_duration') ?? 0) / 86400;
-    const [duration, setDuration] = useState<number>(defaultDuration);
+    const defaultDuration = (form.getValues('usage_duration') ?? null) / 86400;
+    const [duration, setDuration] = useState<number | null>(defaultDuration);
 
     useEffect(() => {
-        form.setValue('usage_duration', duration * 86400);
+        form.setValue('usage_duration', duration !== null ? duration * 86400 : null);
     }, [form, duration]);
 
     return (
@@ -32,10 +32,11 @@ export const UsageDurationField: FC = () => {
                         <Input
                             {...field}
                             type="number"
-                            value={duration}
+                            value={duration !== null ? duration : ''}
                             onChange={(e) => {
-                                setDuration(Number(e.target.value));
-                                field.onChange(e.target.value);
+                                const value = e.target.value !== '' ? Number(e.target.value) : null;
+                                setDuration(value);
+                                field.onChange(value);
                             }}
                         />
                     </FormControl>


### PR DESCRIPTION
Fixes #663

Set the default value of `usage_duration` to `null` in `UsageDurationField` component.

* Initialize the `duration` state with `null`.
* Ensure the input field is empty by default.
* Update the `onChange` handler to handle empty input values and set `duration` to `null` if the input is empty.
* Update the `value` attribute of the input field to display an empty string if `duration` is `null`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/marzneshin/marzneshin/pull/675?shareId=8fb80da5-0ac3-4b28-9b7f-786a6cab6920).