### PR TITLE
feat(admins/enable-disable-users): disable and enable all admin's user

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -154,7 +154,7 @@ def get_admin_users(username: str, db: DBDep, admin: SudoAdminDep):
     return paginate(query)
 
 
-@router.get("/{username}/disable_users", response_model=AdminResponse)
+@router.post("/{username}/disable_users", response_model=AdminResponse)
 async def disable_users(username: str, db: DBDep, admin: SudoAdminDep):
     db_admin = crud.get_admin(db, username)
     if not db_admin:
@@ -176,7 +176,7 @@ async def disable_users(username: str, db: DBDep, admin: SudoAdminDep):
     return db_admin
 
 
-@router.get("/{username}/enable_users", response_model=AdminResponse)
+@router.post("/{username}/enable_users", response_model=AdminResponse)
 async def enable_users(username: str, db: DBDep, admin: SudoAdminDep):
     db_admin = crud.get_admin(db, username)
     if not db_admin:

--- a/dashboard/public/locales/en.json
+++ b/dashboard/public/locales/en.json
@@ -247,6 +247,8 @@
       }
     },
     "admins": {
+      "disable_users": "Disable users",
+      "enable_users": "Enable users",
       "permission": "Permission",
       "dialogs": {
         "creation": {

--- a/dashboard/src/modules/admins/api/disable-admin-users.mutate.ts
+++ b/dashboard/src/modules/admins/api/disable-admin-users.mutate.ts
@@ -1,0 +1,45 @@
+import { useMutation } from "@tanstack/react-query";
+import { fetch, queryClient } from "@marzneshin/common/utils";
+import { toast } from "sonner";
+import i18n from "@marzneshin/features/i18n";
+import { AdminType } from "../types";
+
+interface AdminUsersStatusDisableQuery {
+    admin: AdminType;
+}
+
+export async function adminUsersStatusDisable({ admin }: AdminUsersStatusDisableQuery): Promise<AdminType> {
+    return fetch(`/admins/${admin.username}/disable_users`, { method: 'post' }).then((admin) => {
+        return admin;
+    });
+}
+
+const handleError = (error: Error, value: AdminUsersStatusDisableQuery) => {
+    toast.error(
+        i18n.t('events.user_status.error', { name: value.admin.username }),
+        {
+            description: error.message
+        })
+}
+
+const handleSuccess = (value: AdminType) => {
+    toast.success(
+        i18n.t('events.user_status.success.title', { name: value.username }),
+        {
+            description: i18n.t('events.user_status.success.desc')
+        })
+    queryClient.invalidateQueries({ queryKey: [UsersStatusEnabledFetchKey] })
+    queryClient.invalidateQueries({ queryKey: [UsersStatusEnabledFetchKey, value.username] })
+}
+
+
+const UsersStatusEnabledFetchKey = "admins";
+
+export const useAdminUsersStatusDisable = () => {
+    return useMutation({
+        mutationKey: [UsersStatusEnabledFetchKey],
+        mutationFn: adminUsersStatusDisable,
+        onError: handleError,
+        onSuccess: handleSuccess,
+    })
+}

--- a/dashboard/src/modules/admins/api/enable-admin-users.mutate.ts
+++ b/dashboard/src/modules/admins/api/enable-admin-users.mutate.ts
@@ -1,0 +1,45 @@
+import { useMutation } from "@tanstack/react-query";
+import { fetch, queryClient } from "@marzneshin/common/utils";
+import { toast } from "sonner";
+import i18n from "@marzneshin/features/i18n";
+import { AdminType } from "../types";
+
+interface AdminUsersStatusEnableQuery {
+    admin: AdminType;
+}
+
+export async function adminUsersStatusEnable({ admin }: AdminUsersStatusEnableQuery): Promise<AdminType> {
+    return fetch(`/admins/${admin.username}/enable_users`, { method: 'post' }).then((admin) => {
+        return admin;
+    });
+}
+
+const handleError = (error: Error, value: AdminUsersStatusEnableQuery) => {
+    toast.error(
+        i18n.t('events.user_status.error', { name: value.admin.username }),
+        {
+            description: error.message
+        })
+}
+
+const handleSuccess = (value: AdminType) => {
+    toast.success(
+        i18n.t('events.user_status.success.title', { name: value.username }),
+        {
+            description: i18n.t('events.user_status.success.desc')
+        })
+    queryClient.invalidateQueries({ queryKey: [UsersStatusEnabledFetchKey] })
+    queryClient.invalidateQueries({ queryKey: [UsersStatusEnabledFetchKey, value.username] })
+}
+
+
+const UsersStatusEnabledFetchKey = "admins";
+
+export const useAdminUsersStatusEnable = () => {
+    return useMutation({
+        mutationKey: [UsersStatusEnabledFetchKey],
+        mutationFn: adminUsersStatusEnable,
+        onError: handleError,
+        onSuccess: handleSuccess,
+    })
+}

--- a/dashboard/src/modules/admins/api/index.ts
+++ b/dashboard/src/modules/admins/api/index.ts
@@ -3,3 +3,5 @@ export * from "./admin.query";
 export * from "./update-admin.mutate";
 export * from "./create-admin.mutate";
 export * from "./delete-admin.mutate";
+export * from "./disable-admin-users.mutate";
+export * from "./enable-admin-users.mutate";

--- a/dashboard/src/modules/admins/components/dialogs/settings/admin-info/table.tsx
+++ b/dashboard/src/modules/admins/components/dialogs/settings/admin-info/table.tsx
@@ -1,4 +1,5 @@
 import {
+    Button,
     Card,
     CardContent,
     CardHeader,
@@ -7,23 +8,50 @@ import {
     TableBody,
     TableRowWithCell,
 } from "@marzneshin/common/components";
-import { FC } from "react";
+import { FC, useCallback } from "react";
 import {
     type AdminProp,
     AdminEnabledPill,
-    AdminPermissionPill
+    AdminPermissionPill,
+    useAdminUsersStatusDisable,
+    useAdminUsersStatusEnable
 } from "@marzneshin/modules/admins";
 import { useTranslation } from "react-i18next";
+import { LoaderIcon, UserCheck, UserX } from "lucide-react";
 import { format } from '@chbphone55/pretty-bytes';
 
 export const AdminInfoTable: FC<AdminProp> = ({ admin: entity }) => {
     const { t } = useTranslation();
     const usersDataUsage = format(entity.users_data_usage);
+    const { mutate: adminStatusEnable, isPending: enablePending } = useAdminUsersStatusEnable()
+    const { mutate: adminStatusDisable, isPending: disablePending } = useAdminUsersStatusDisable()
+
+    const handleAdmingStatusEnable = useCallback(() => {
+        adminStatusEnable({ admin: entity })
+    }, [entity, adminStatusEnable]);
+
+    const handleAdmingStatusDisable = useCallback(() => {
+        adminStatusDisable({ admin: entity })
+    }, [entity, adminStatusDisable]);
 
     return (
         <Card>
             <CardHeader className="flex flex-row justify-between items-center w-full">
                 <CardTitle>{t("admin_info")}</CardTitle>
+                <div className="hstack justify-center items-center gap-2">
+                    <Button
+                        className={"bg-destructive rounded-2xl"}
+                        onClick={handleAdmingStatusDisable}
+                    >
+                        {disablePending ? <LoaderIcon className="animate-spin" /> : (<><UserX className="mr-2" /> {t('page.admins.disable_users')} </>)}
+                    </Button>
+                    <Button
+                        className="bg-success rounded-2xl"
+                        onClick={handleAdmingStatusEnable}
+                    >
+                        {enablePending ? <LoaderIcon className="animate-spin" /> : (<><UserCheck className="mr-2" /> {t('page.admins.enable_users')} </>)}
+                    </Button>
+                </div>
             </CardHeader>
             <CardContent>
                 <Table>


### PR DESCRIPTION
## Description

Two button to mutate the state of all users of an admin.

## UI Changes

- **translate(admins/enable-disable-users): english translation**
- **feat(admins/enable-disable-users): API commands for enable and disable of all users**
- **feat(admins/enable-disable-users): buttons for enable and disable**

### Screenshots

![image](https://github.com/user-attachments/assets/48df7bd3-8cf4-4e96-a21a-a83d16a53143)


## API Changes

- **fix(admins/api): correcting the http methods of enable_users and disable_users**
  - HTTP method of the following endpoints have been changed to `POST`
    - `GET /api/admins/{username}/disable_users`
    - `GET /api/admins/{username}/enable_users`
  - The standard HTTP method for requests that change the system state is `POST`.

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests (stories, interaction tests, unit tests, e2e tests) to cover my changes.
- [ ] I have added tests to cover my changes.

## Related Issues

Closes #568

- #568
