### PR TITLE
fix(db): preserve node user usages when a node is removed

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -414,7 +414,7 @@ class Node(Base):
     user_usages = relationship(
         "NodeUserUsage",
         back_populates="node",
-        cascade="all, delete, delete-orphan",
+        cascade="save-update, merge",
     )
     usages = relationship(
         "NodeUsage",


### PR DESCRIPTION
## Description

Stops sqlalchemy from removing node_user_usages when a node is removed

