### PR TITLE
fix(subscription): update v2share to get tcp transport right

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ aiohttp==3.10.2
 xxhash==3.4.1
 grpcio==1.65.4
 psycopg==3.1.18
-v2share==0.1.0b26
+v2share==0.1.0b27
 PyJWT~=2.8.0
 PyNaCl==1.5.0
 starlette==0.40.0


### PR DESCRIPTION
## Description

Fixes subscription output for sing-box, where transport is incorrectly set to tcp + http headers for plain tcp.