### PR TITLE
fix(nodes): node config modification timeout

### DIFF
--- a/app/routes/node.py
+++ b/app/routes/node.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Annotated
 
@@ -225,5 +226,7 @@ async def alter_node_xray_config(
             5,
         )
     except:
-        raise HTTPException(status_code=502, detail="Node isn't responsive")
+        raise HTTPException(
+            status_code=502, detail="No response from the node."
+        )
     return {}

--- a/app/routes/node.py
+++ b/app/routes/node.py
@@ -192,7 +192,7 @@ async def get_backend_stats(
 
 @router.get("/{node_id}/{backend}/config", response_model=BackendConfig)
 async def get_node_xray_config(
-    node_id: int, backend: str, db: DBDep, admin: SudoAdminDep
+    node_id: int, backend: str, admin: SudoAdminDep
 ):
     if not (node := marznode.nodes.get(node_id)):
         raise HTTPException(status_code=404, detail="Node not found")
@@ -209,7 +209,6 @@ async def get_node_xray_config(
 async def alter_node_xray_config(
     node_id: int,
     backend: str,
-    db: DBDep,
     admin: SudoAdminDep,
     config: Annotated[BackendConfig, Body()],
 ):

--- a/app/routes/node.py
+++ b/app/routes/node.py
@@ -92,7 +92,7 @@ async def node_logs(
     db: DBDep,
     include_buffer: bool = True,
 ):
-    token = websocket.query_params.get("token") or websocket.headers.get(
+    token = websocket.query_params.get("token", "") or websocket.headers.get(
         "Authorization", ""
     ).removeprefix("Bearer ")
     admin = get_admin(db, token)
@@ -112,7 +112,7 @@ async def node_logs(
                 await websocket.send_text(line)
             except WebSocketDisconnect:
                 break
-    except:
+    finally:
         await websocket.close()
 
 

--- a/app/routes/node.py
+++ b/app/routes/node.py
@@ -215,11 +215,15 @@ async def alter_node_xray_config(
 ):
     if not (node := marznode.nodes.get(node_id)):
         raise HTTPException(status_code=404, detail="Node not found")
+
     try:
-        await node.restart_backend(
-            name=backend,
-            config=config.config,
-            config_format=config.format.value,
+        await asyncio.wait_for(
+            node.restart_backend(
+                name=backend,
+                config=config.config,
+                config_format=config.format.value,
+            ),
+            5,
         )
     except:
         raise HTTPException(status_code=502, detail="Node isn't responsive")


### PR DESCRIPTION
## Description

In case the node doesn't respond to the restart request, prevents the endpoint from getting stalled by setting a timeout.