### PR TITLE
feat(subscription): Allow removing default '/sub' from subscription url

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -270,10 +270,16 @@ class User(Base):
         prefix = (
             self.admin.subscription_url_prefix if self.admin else None
         ) or SUBSCRIPTION_URL_PREFIX
-        return (
-            prefix.replace("*", secrets.token_hex(8))
-            + f"/sub/{self.username}/{self.key}"
-        )
+        if prefix.count('/') > 2:
+            return (
+                prefix.replace("*", secrets.token_hex(8))
+                + f"/{self.username}/{self.key}"
+            )
+        else:
+            return (
+                prefix.replace("*", secrets.token_hex(8))
+                + f"/sub/{self.username}/{self.key}"
+            )
 
     @hybrid_property
     def owner_username(self):


### PR DESCRIPTION
## Description

Allow changing default '/sub' path of subscription url by using :
https://example.com/any
instead of
https://example.com
for SUBSCRIPTION_URL_PREFIX

needs help of reverse proxy to redirect the default /sub path to the custom one

## UI Changes

-
-

### Screenshots

## API Changes

## Checklist
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests (stories, interaction tests, unit tests, e2e tests) to cover my changes.
- [ ] I have added tests to cover my changes.

## Related Issues

Closes

- #
- #

