### PR TITLE
ci: set vite app version explicitly when building

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -59,6 +59,8 @@ jobs:
         working-directory: ./dashboard/
 
       - name: Build Dashboard
+        env:
+          VITE_LATEST_APP_VERSION: ${{ github.ref_name }}
         run: npm run build --if-present -- --outDir 'dist' --assetsDir 'static'
         working-directory: ./dashboard/
 


### PR DESCRIPTION
## Description

explicitly set dashboard version as a variable
