### PR TITLE
fix: add is_removed filter to admin users

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -149,7 +149,9 @@ def get_admin_users(username: str, db: DBDep, admin: SudoAdminDep):
     if not db_admin:
         raise HTTPException(status_code=404, detail="Admin not found")
 
-    query = db.query(User).where(User.admin_id == db_admin.id)
+    query = db.query(User).filter(
+        User.admin_id == db_admin.id, User.removed.is_(False)
+    )
 
     return paginate(query)
 


### PR DESCRIPTION
because:
``` 
marzneshin-1  | INFO:     80.253.254.3:0 - "GET /api/admins/b9ef89/users?size=100&page=1 HTTP/1.1" 500 Internal Server Error
marzneshin-1  | ERROR:    Exception in ASGI application
marzneshin-1  | Traceback (most recent call last):
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/uvicorn/protocols/http/httptools_impl.py", line 399, in run_asgi
marzneshin-1  |     result = await app(  # type: ignore[func-returns-value]
marzneshin-1  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/uvicorn/middleware/proxy_headers.py", line 70, in __call__
marzneshin-1  |     return await self.app(scope, receive, send)
marzneshin-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/fastapi/applications.py", line 1054, in __call__
marzneshin-1  |     await super().__call__(scope, receive, send)
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/starlette/applications.py", line 113, in __call__
marzneshin-1  |     await self.middleware_stack(scope, receive, send)
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/starlette/middleware/errors.py", line 187, in __call__
marzneshin-1  |     raise exc
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/starlette/middleware/errors.py", line 165, in __call__
marzneshin-1  |     await self.app(scope, receive, _send)
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/starlette/middleware/cors.py", line 85, in __call__
marzneshin-1  |     await self.app(scope, receive, send)
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
marzneshin-1  |     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
marzneshin-1  |     raise exc
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
marzneshin-1  |     await app(scope, receive, sender)
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/starlette/routing.py", line 715, in __call__
marzneshin-1  |     await self.middleware_stack(scope, receive, send)
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/starlette/routing.py", line 735, in app
marzneshin-1  |     await route.handle(scope, receive, send)
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/starlette/routing.py", line 288, in handle
marzneshin-1  |     await self.app(scope, receive, send)
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/starlette/routing.py", line 76, in app
marzneshin-1  |     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
marzneshin-1  |     raise exc
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
marzneshin-1  |     await app(scope, receive, sender)
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/starlette/routing.py", line 73, in app
marzneshin-1  |     response = await f(request)
marzneshin-1  |                ^^^^^^^^^^^^^^^^
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/fastapi/routing.py", line 301, in app
marzneshin-1  |     raw_response = await run_endpoint_function(
marzneshin-1  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/fastapi/routing.py", line 214, in run_endpoint_function
marzneshin-1  |     return await run_in_threadpool(dependant.call, **values)
marzneshin-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/starlette/concurrency.py", line 39, in run_in_threadpool
marzneshin-1  |     return await anyio.to_thread.run_sync(func, *args)
marzneshin-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/anyio/to_thread.py", line 56, in run_sync
marzneshin-1  |     return await get_async_backend().run_sync_in_worker_thread(
marzneshin-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 2461, in run_sync_in_worker_thread
marzneshin-1  |     return await future
marzneshin-1  |            ^^^^^^^^^^^^
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 962, in run
marzneshin-1  |     result = context.run(func, *args)
marzneshin-1  |              ^^^^^^^^^^^^^^^^^^^^^^^^
marzneshin-1  |   File "/app/app/routes/admin.py", line 154, in get_admin_users
marzneshin-1  |     return paginate(query)
marzneshin-1  |            ^^^^^^^^^^^^^^^
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/fastapi_pagination/ext/sqlalchemy.py", line 368, in paginate
marzneshin-1  |     return exec_pagination(
marzneshin-1  |            ^^^^^^^^^^^^^^^^
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/fastapi_pagination/ext/sqlalchemy.py", line 267, in exec_pagination
marzneshin-1  |     return create_page(
marzneshin-1  |            ^^^^^^^^^^^^
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/fastapi_pagination/api.py", line 182, in create_page
marzneshin-1  |     return _page_val.get().create(items, **kwargs)
marzneshin-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/fastapi_pagination/default.py", line 73, in create
marzneshin-1  |     return create_pydantic_model(
marzneshin-1  |            ^^^^^^^^^^^^^^^^^^^^^^
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/fastapi_pagination/utils.py", line 171, in create_pydantic_model
marzneshin-1  |     return model_cls.model_validate(kwargs, from_attributes=True)  # type: ignore
marzneshin-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
marzneshin-1  |   File "/usr/local/lib/python3.12/site-packages/pydantic/main.py", line 622, in model_validate
marzneshin-1  |     return cls.__pydantic_validator__.validate_python(
marzneshin-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
marzneshin-1  | pydantic_core._pydantic_core.ValidationError: 18 validation errors for Page[UserResponse]
marzneshin-1  | items.0.username
marzneshin-1  |   Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
marzneshin-1  |     For further information visit https://errors.pydantic.dev/2.10/v/string_type
marzneshin-1  | items.1.username
marzneshin-1  |   Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
marzneshin-1  |     For further information visit https://errors.pydantic.dev/2.10/v/string_type
marzneshin-1  | items.2.username
marzneshin-1  |   Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
marzneshin-1  |     For further information visit https://errors.pydantic.dev/2.10/v/string_type
marzneshin-1  | items.3.username
marzneshin-1  |   Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
marzneshin-1  |     For further information visit https://errors.pydantic.dev/2.10/v/string_type
marzneshin-1  | items.4.username
marzneshin-1  |   Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
marzneshin-1  |     For further information visit https://errors.pydantic.dev/2.10/v/string_type
marzneshin-1  | items.5.username
marzneshin-1  |   Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
marzneshin-1  |     For further information visit https://errors.pydantic.dev/2.10/v/string_type
marzneshin-1  | items.6.username
marzneshin-1  |   Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
marzneshin-1  |     For further information visit https://errors.pydantic.dev/2.10/v/string_type
marzneshin-1  | items.7.username
marzneshin-1  |   Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
marzneshin-1  |     For further information visit https://errors.pydantic.dev/2.10/v/string_type
marzneshin-1  | items.8.username
marzneshin-1  |   Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
marzneshin-1  |     For further information visit https://errors.pydantic.dev/2.10/v/string_type
marzneshin-1  | items.9.username
marzneshin-1  |   Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
marzneshin-1  |     For further information visit https://errors.pydantic.dev/2.10/v/string_type
marzneshin-1  | items.10.username
marzneshin-1  |   Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
marzneshin-1  |     For further information visit https://errors.pydantic.dev/2.10/v/string_type
marzneshin-1  | items.11.username
marzneshin-1  |   Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
marzneshin-1  |     For further information visit https://errors.pydantic.dev/2.10/v/string_type
marzneshin-1  | items.12.username
marzneshin-1  |   Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
marzneshin-1  |     For further information visit https://errors.pydantic.dev/2.10/v/string_type
marzneshin-1  | items.15.username
marzneshin-1  |   Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
marzneshin-1  |     For further information visit https://errors.pydantic.dev/2.10/v/string_type
marzneshin-1  | items.16.username
marzneshin-1  |   Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
marzneshin-1  |     For further information visit https://errors.pydantic.dev/2.10/v/string_type
marzneshin-1  | items.17.username
marzneshin-1  |   Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
marzneshin-1  |     For further information visit https://errors.pydantic.dev/2.10/v/string_type
marzneshin-1  | items.18.username
marzneshin-1  |   Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
marzneshin-1  |     For further information visit https://errors.pydantic.dev/2.10/v/string_type
marzneshin-1  | items.19.username
marzneshin-1  |   Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
marzneshin-1  |     For further information visit https://errors.pydantic.dev/2.10/v/string_type
```