### PR TITLE
improve: replace direct api with aiogram

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -91,7 +91,7 @@ def get_user(
 
 
 def user_modification_access(
-    admin: Annotated[Admin, Depends(get_current_admin)]
+    admin: Annotated[Admin, Depends(get_current_admin)],
 ):
     if not admin.is_sudo and not admin.modify_users_access:
         raise HTTPException(status_code=403, detail="You're not allowed")

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,5 @@ uvicorn==0.30.4
 rich==13.7.1
 python-multipart==0.0.20
 httptools==0.6.4
-aiogram==3.17.0
 bcrypt==4.2.1
 aiohttp-socks==0.10.1


### PR DESCRIPTION
## Description

جایگزینی درخواست مستقیم به بات تلگرام با لایبری آیوگرام به دلیل مصرف رم منابع بیش از حد و غیر منطقی دلیل این پول ریکویست می باشد. ذاتا ما از ایوگرام فقط برای ولیدیشن و ارسال پیام ها استفاده میکنیم، پس نیازی بهش نداریم. میتونیم با api مستقیم تلگرام ولیدیشن و پیام هارو ارسال کنیم. شاید بپرسید مگه ایوگرام چقدر مصرف رم داشت؟ 125 مگ لعنتی!!!! fastapi که مرکز سیستم مرزنشین می باشد، 30 مگابایت مصرف رم هم نداره، پس غیرمنظقیه یک لایبری بی نیاز رو با این همه مصرف در سیستم نگه داریم.

