### PR TITLE
Fix cli commands error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ python-decouple==3.8
 python-dotenv==1.0.0
 requests==2.32.2
 SQLAlchemy==2.0.37
-typer==0.12.3
+typer==0.19.2
 websockets==12.0
 PyYAML==6.0.1
 aiohttp==3.11.11


### PR DESCRIPTION
Upgrade Typer lib to 0.19.2 to resolve this issue:

```TypeError: Parameter.make_metavar() missing 1 required positional argument: 'ctx'```

